### PR TITLE
Add option to hide Bluetooth Icon when disconnected in Status Bar (1/2)

### DIFF
--- a/api/current.txt
+++ b/api/current.txt
@@ -25395,6 +25395,7 @@ package android.provider {
     field public static final deprecated java.lang.String SETTINGS_CLASSNAME = "settings_classname";
     field public static final java.lang.String SETUP_WIZARD_HAS_RUN = "setup_wizard_has_run";
     field public static final java.lang.String SHOW_ALARM_ICON = "show_alarm_icon";
+    field public static final java.lang.String SHOW_BlUETOOTH_ICON = "show_bluetooth_icon";
     field public static final java.lang.String SHOW_GTALK_SERVICE_STATUS = "SHOW_GTALK_SERVICE_STATUS";
     field public static final deprecated java.lang.String SHOW_PROCESSES = "show_processes";
     field public static final deprecated java.lang.String SHOW_WEB_SUGGESTIONS = "show_web_suggestions";

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2091,6 +2091,11 @@ public final class Settings {
         public static final String SHOW_ALARM_ICON = "show_alarm_icon";
 
         /**
+         * Option to hide the Bluetooth icon in the status bar when disconnected.
+         */
+        public static final String SHOW_BLUETOOTH_ICON = "show_bluetooth_icon";
+
+        /**
          * Scaling factor for fonts, float.
          */
         public static final String FONT_SCALE = "font_scale";


### PR DESCRIPTION
Add an option to hide the bluetooth icon from the status bar when it is enabled, but disconnected / not connected. The icon will still be shown when it is connected. This behavior will be similar to the wifi icon (hidden when wifi is on but not connected). Useful when you have bluetooth open all the time, but you don't want to see the icon unless connected.

Credits to mnm9994u and MrBaNkS for "Add option to hide AlarmClock Icon in StatusBar [1/2]" https://github.com/SimpleAOSP-Lollipop/platform_frameworks_base/commit/5ef3106a669bf765e1d34628d912df624b07dc1f
