### PR TITLE
merge derp FIX: 'Add option to Hide Bluetooth icon'

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
@@ -163,6 +163,11 @@ public class PhoneStatusBarPolicy {
         mContext.getContentResolver().registerContentObserver(
                 Settings.System.getUriFor(Settings.System.SHOW_ALARM_ICON),
                 false, mAlarmIconObserver);
+                
+        mBluetoothIconObserver.onChange(true);
+        mContext.getContentResolver().registerContentObserver(
+                Settings.System.getUriFor(Settings.System.SHOW_BLUETOOTH_ICON),
+                false, mBluetoothIconObserver);      
     }
 
     private ContentObserver mAlarmIconObserver = new ContentObserver(null) {


### PR DESCRIPTION
I forgot to add this piece of code while merging. It caused the bluetooth icon to never appear, regardless of preference. I think that now I got that fixed.
